### PR TITLE
Add navigation to profile options

### DIFF
--- a/keen_app/keen_app.xcodeproj/project.pbxproj
+++ b/keen_app/keen_app.xcodeproj/project.pbxproj
@@ -9,6 +9,9 @@
 /* Begin PBXBuildFile section */
 		1F2C69732BD51308008F9B94 /* ProfileModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F2C69722BD51308008F9B94 /* ProfileModel.swift */; };
 		1F2C69772BD522E6008F9B94 /* ProfileViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F2C69762BD522E6008F9B94 /* ProfileViewModel.swift */; };
+		1F2E9F652C21C08200B517DB /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F2E9F642C21C08200B517DB /* SettingsView.swift */; };
+		1F2E9F672C21C0AF00B517DB /* FriendsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F2E9F662C21C0AF00B517DB /* FriendsView.swift */; };
+		1F2E9F692C21C46400B517DB /* HeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F2E9F682C21C46400B517DB /* HeaderView.swift */; };
 		1F5189B22BDF721F007E6F96 /* MainView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F5189B12BDF721F007E6F96 /* MainView.swift */; };
 		1F5189B42BDF7231007E6F96 /* HomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F5189B32BDF7231007E6F96 /* HomeView.swift */; };
 		1F5189B62BDF7238007E6F96 /* AddActivityView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F5189B52BDF7238007E6F96 /* AddActivityView.swift */; };
@@ -44,6 +47,9 @@
 /* Begin PBXFileReference section */
 		1F2C69722BD51308008F9B94 /* ProfileModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileModel.swift; sourceTree = "<group>"; };
 		1F2C69762BD522E6008F9B94 /* ProfileViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileViewModel.swift; sourceTree = "<group>"; };
+		1F2E9F642C21C08200B517DB /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
+		1F2E9F662C21C0AF00B517DB /* FriendsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FriendsView.swift; sourceTree = "<group>"; };
+		1F2E9F682C21C46400B517DB /* HeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeaderView.swift; sourceTree = "<group>"; };
 		1F5189B12BDF721F007E6F96 /* MainView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = MainView.swift; path = keen_app/MainView.swift; sourceTree = SOURCE_ROOT; };
 		1F5189B32BDF7231007E6F96 /* HomeView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HomeView.swift; sourceTree = "<group>"; };
 		1F5189B52BDF7238007E6F96 /* AddActivityView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AddActivityView.swift; sourceTree = "<group>"; };
@@ -117,8 +123,11 @@
 				1FC240142BDFB441002DE8DC /* MyActivitiesModel.swift */,
 				1F5189B32BDF7231007E6F96 /* HomeView.swift */,
 				1FDB49112BD4FED600945410 /* ProfileView.swift */,
+				1F2E9F642C21C08200B517DB /* SettingsView.swift */,
 				1F2C69722BD51308008F9B94 /* ProfileModel.swift */,
 				1F2C69762BD522E6008F9B94 /* ProfileViewModel.swift */,
+				1F2E9F662C21C0AF00B517DB /* FriendsView.swift */,
+				1F2E9F682C21C46400B517DB /* HeaderView.swift */,
 				1FDB49132BD4FED700945410 /* Assets.xcassets */,
 				1FDB49152BD4FED700945410 /* Preview Content */,
 			);
@@ -283,14 +292,17 @@
 			files = (
 				1FDB49122BD4FED600945410 /* ProfileView.swift in Sources */,
 				1F5189B82BDF7241007E6F96 /* MainView.swift in Sources */,
+				1F2E9F652C21C08200B517DB /* SettingsView.swift in Sources */,
 				1F5189B62BDF7238007E6F96 /* AddActivityView.swift in Sources */,
 				1F2C69732BD51308008F9B94 /* ProfileModel.swift in Sources */,
 				1F2C69772BD522E6008F9B94 /* ProfileViewModel.swift in Sources */,
+				1F2E9F672C21C0AF00B517DB /* FriendsView.swift in Sources */,
 				1F5189B42BDF7231007E6F96 /* HomeView.swift in Sources */,
 				1FC240152BDFB441002DE8DC /* MyActivitiesModel.swift in Sources */,
 				1F5189B22BDF721F007E6F96 /* MainView.swift in Sources */,
 				1FC240132BDFB21D002DE8DC /* MyActivitiesView.swift in Sources */,
 				1FDB49102BD4FED600945410 /* keenApp.swift in Sources */,
+				1F2E9F692C21C46400B517DB /* HeaderView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/keen_app/keen_app/FriendsView.swift
+++ b/keen_app/keen_app/FriendsView.swift
@@ -1,0 +1,34 @@
+//
+//  FriendsView.swift
+//  keen_app
+//
+//  Created by Jennifer Tan on 6/18/24.
+//
+
+import SwiftUI
+
+struct FriendsView: View {
+    @Environment(\.presentationMode) var presentation
+    var body: some View {
+        VStack(alignment: .center, spacing: 30) {
+            HeaderView(
+                icon: "chevron.left",
+                iconAction: { presentation.wrappedValue.dismiss() },
+                heading: "Friends"
+            )
+            ScrollView {
+                // TODO: Add Friends page content
+            }
+        }
+        .padding(.top, 15)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(Color(.systemGray6))
+        .navigationBarBackButtonHidden(true)
+    }
+}
+
+struct FriendsView_Previews: PreviewProvider {
+    static var previews: some View {
+        FriendsView()
+    }
+}

--- a/keen_app/keen_app/HeaderView.swift
+++ b/keen_app/keen_app/HeaderView.swift
@@ -1,0 +1,39 @@
+//
+//  HeaderView.swift
+//  keen_app
+//
+//  Created by Jennifer Tan on 6/18/24.
+//
+
+import SwiftUI
+
+struct HeaderView: View {
+    var icon: String
+    var iconAction: (() -> Void)
+    var heading: String
+    
+    var body: some View {
+        HStack {
+            Button(
+                action: iconAction,
+                label: {
+                    Image(systemName: icon)
+                        .foregroundColor(.black)
+                        .font(.system(size: 20))
+                }
+            )
+            Spacer()
+            Text(heading)
+                .font(.system(size: 20, weight: .bold))
+            Spacer()
+        }
+        .frame(width: 332)
+    }
+}
+
+struct HeaderView_Previews: PreviewProvider {
+    static var previews: some View {
+        HeaderView(icon: "chevron.left", iconAction: { print("Test") }, heading: "Heading")
+    }
+}
+

--- a/keen_app/keen_app/MyActivitiesView.swift
+++ b/keen_app/keen_app/MyActivitiesView.swift
@@ -9,18 +9,26 @@ import Foundation
 import SwiftUI
 
 struct MyActivitiesView: View {
+    @Environment(\.presentationMode) var presentation
     @StateObject var viewModel: ProfileViewModel
     
     var body: some View {
         VStack(alignment: .center, spacing: 30) {
-            Text("My activities")
-                .font(.system(size: 20, weight: .bold))
-            ActivityList(viewModel: viewModel)
-            Spacer()
+            HeaderView(
+                icon: "chevron.left",
+                iconAction: { presentation.wrappedValue.dismiss() },
+                heading: "My activities"
+            )
+            
+            // Page content to be scrolled
+            ScrollView {
+                ActivityList(viewModel: viewModel)
+            }
         }
         .padding(.top, 15)
-        .containerRelativeFrame([.horizontal, .vertical])
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
         .background(Color(.systemGray6))
+        .navigationBarBackButtonHidden(true)
     }
 }
 

--- a/keen_app/keen_app/ProfileView.swift
+++ b/keen_app/keen_app/ProfileView.swift
@@ -17,6 +17,8 @@ struct ProfileView: View {
                 ProfileListView(viewModel: viewModel)
                 Spacer()
             }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .background(Color(.systemGray6))
         }
         .foregroundColor(.black)
     }

--- a/keen_app/keen_app/ProfileView.swift
+++ b/keen_app/keen_app/ProfileView.swift
@@ -37,29 +37,49 @@ struct ProfileDetails: View {
 
 struct ProfileListView: View {
     @StateObject var viewModel: ProfileViewModel
-    
+
     var body: some View {
         VStack {
-            ForEach(viewModel.profileItems) { item in
-                NavigationLink(
-                    destination: MyActivitiesView(viewModel: viewModel)
-                ) {
-                    HStack {
-                        item.icon
-                            .frame(width: 40)
-                        Text(item.settingsName)
-                            .font(.system(size: 16, weight: .semibold))
-                        Spacer()
-                        Image(systemName: "chevron.right")
-                            .frame(width: 40)
-                    }
-                    .frame(width: 342, height: 50)
-                    .contentShape(Rectangle())
-                }
-                Divider()
-                    .frame(width: 332)
-            }
+            profileOptionView(
+                destination: MyActivitiesView(viewModel: viewModel),
+                icon: "list.bullet",
+                name: "My activities"
+            )
+            profileOptionView(
+                destination: SettingsView(),
+                icon: "gearshape.fill",
+                name: "Account settings"
+            )
+            profileOptionView(
+                destination: FriendsView(),
+                icon: "heart.fill",
+                name: "Friends"
+            )
         }
+    }
+}
+
+struct profileOptionView<Destination: View>: View {
+    var destination: Destination
+    var icon: String
+    var name: String
+    
+    var body: some View {
+        NavigationLink(destination: destination) {
+            HStack {
+                Image(systemName: icon)
+                    .frame(width: 40)
+                Text(name)
+                    .font(.system(size: 16, weight: .semibold))
+                Spacer()
+                Image(systemName: "chevron.right")
+                    .frame(width: 40)
+            }
+            .frame(width: 342, height: 50)
+            .contentShape(Rectangle())
+        }
+        Divider()
+            .frame(width: 332)
     }
 }
 

--- a/keen_app/keen_app/ProfileViewModel.swift
+++ b/keen_app/keen_app/ProfileViewModel.swift
@@ -34,7 +34,6 @@ class ProfileViewModel: ObservableObject {
     @Published var error: Error? = nil
     @Published var usersList: [User?] = []
     private var cancellables = Set<AnyCancellable>()
-    @Published var profileItems: [ProfileItem] = []
     // Dummy user and activity details as fallback
     @Published var activities: [Activity] = dummyActivitiesData
     @Published var userDetails: User? = dummyUserDetails
@@ -43,14 +42,8 @@ class ProfileViewModel: ObservableObject {
     // Consolidated initializer
     init(apiService: ApiService = ApiService(), userDetails: User? = nil) {
         self.apiService = apiService
-        addProfileItems()
         addUserDetails(username: currentUsername)  // Get user details from db
         addActivities(username: currentUsername)  // Get user activities from db
-    }
-
-    // Function to add profile items
-    func addProfileItems() {
-        profileItems = profileData
     }
     
     // Function to add user activities
@@ -90,12 +83,6 @@ class ProfileViewModel: ObservableObject {
     }
     
 }
-
-let profileData = [
-    ProfileItem(settingsName: "My activities", icon: Image(systemName: "list.bullet")),
-    ProfileItem(settingsName: "Account settings", icon: Image(systemName: "gearshape.fill")),
-    ProfileItem(settingsName: "Friends", icon: Image(systemName: "heart.fill"))
-]
 
 let dummyActivitiesData = [
     Activity(name: "Kayaking", visibility: "private",

--- a/keen_app/keen_app/SettingsView.swift
+++ b/keen_app/keen_app/SettingsView.swift
@@ -1,0 +1,34 @@
+//
+//  SettingsView.swift
+//  keen_app
+//
+//  Created by Jennifer Tan on 6/18/24.
+//
+
+import SwiftUI
+
+struct SettingsView: View {
+    @Environment(\.presentationMode) var presentation
+    var body: some View {
+        VStack(alignment: .center, spacing: 30) {
+            HeaderView(
+                icon: "chevron.left",
+                iconAction: { presentation.wrappedValue.dismiss() },
+                heading: "Settings"
+            )
+            ScrollView {
+                // TODO: Add Settings page content
+            }
+        }
+        .padding(.top, 15)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(Color(.systemGray6))
+        .navigationBarBackButtonHidden(true)
+    }
+}
+
+struct SettingsView_Previews: PreviewProvider {
+    static var previews: some View {
+        SettingsView()
+    }
+}


### PR DESCRIPTION
Closes #23 and #29 

- Create a reusable HeaderView for page headers
- Added navigation to all screens in Profile page
- Added a custom back button as per the Figma
- Separating each profile option into a struct for better organisation and cleaner code :)
- Profile options removed from ViewModel as it does not to be loaded/it is always the same for everyone so can just be moved to View


https://github.com/keen-app/keen/assets/63948459/641e0789-1fe4-45d3-80ee-1e2e8c2e7925

